### PR TITLE
fix: commit-message.prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(GitHub Actions): "
+      prefix: "chore(ci): "
     reviewers:
       - "Meru92"
     target-branch: master


### PR DESCRIPTION
**Issue:** No

### Type of Change:

設定ファイル( dependabot.yml )の修正(fix)

### Cause of the Problem (問題の原因)

本来 `15文字` に抑える必要のある `commit-message.prefix` を 20文字 近く指定していた

### Dealing with Problems (問題への対処)

`11文字` で抑えた

![image](https://user-images.githubusercontent.com/82575685/172622915-3f31f52d-0d28-4913-9259-eb78a8aa28ff.png)

